### PR TITLE
HTTP and IPFS Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Video player build using atom-shell and node.js
 
 It currently has support for playing mp4/webm and chromecasting videos.
-In addition to that it supports live streaming of video shared using a BitTorrent magnet link.
+In addition to that it supports live streaming of video using http links, BitTorrent magnet links, and IPFS links.
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "duplexify": "^3.2.0",
     "end-of-stream": "^1.1.0",
     "filereader-stream": "^0.2.0",
+    "http-client-stream": "^0.3.0",
     "minimist": "^1.1.1",
     "multicast-dns": "^2.0.0",
     "network-address": "^1.0.0",

--- a/playlist.js
+++ b/playlist.js
@@ -4,6 +4,7 @@ var duplex = require('duplexify')
 var ytdl = require('ytdl-core')
 var events = require('events')
 var path = require('path')
+var httpStream = require('http-client-stream')
 var fs = require('fs')
 var vtt = require('srt-to-vtt')
 var concat = require('concat-stream')
@@ -48,12 +49,12 @@ module.exports = function () {
       onmagnet(buf, cb)
     })
   }
-  
+
   var onyoutube = function (link, cb) {
     var file = {}
     var url = link.split(':')[1]
     url = 'https:' + url
-    
+
     getYoutubeData(function (err, data) {
       if (err) return cb(err)
       var fmt = data.fmt
@@ -64,7 +65,7 @@ module.exports = function () {
         if (!len) return cb(new Error('no content-length on response'))
         file.length = +len
         file.name = info.title
-    
+
         file.createReadStream = function (opts) {
           // fetch this for every range request
           // TODO try and avoid doing this call twice the first time
@@ -74,27 +75,27 @@ module.exports = function () {
             if (opts.start || opts.end) vidUrl += '&range=' + ([opts.start || 0, opts.end || len].join('-'))
             stream.setReadable(request(vidUrl))
           })
-          
+
           var stream = duplex()
           return stream
         }
         file.id = that.entries.push(file) - 1
         that.emit('update')
-        cb()  
+        cb()
       })
     })
-    
+
     function getYoutubeData(cb) {
       ytdl.getInfo(url, function (err, info) {
         if (err) return cb(err)
 
         var vidFmt
         var formats = info.formats
-      
+
         formats.sort(function sort (a, b) {
           return +a.itag - +b.itag
         })
-      
+
         var vidFmt
         formats.forEach(function (fmt) {
           // prefer webm
@@ -153,6 +154,44 @@ module.exports = function () {
     })
   }
 
+  var onhttplink = function (link, cb) {
+    var file = httpStream(link)
+
+    // call the http-stream's createStream with given range.
+    file.createReadStream = function(range) {
+      var rangestr = "bytes=" + range.start + '-' + range.end
+      var opts = {"headers": {"Range": rangestr} }
+
+      var stream = file.createStream(opts)
+      stream.end()
+      return stream
+    }
+
+    // first, get the head for the content length.
+    // IMPORTANT: servers without HEAD will not work.
+    var head = file.createStream({method: 'HEAD'})
+    head.on('response', function() {
+      if (!/2\d\d/.test(head.res.statusCode))
+        cb(new Error("request failed"))
+
+      // get the file length
+      file.length = head.res.headers['content-length']
+      console.log('found stream of length ' + file.length)
+
+      // ok it worked. add the file.
+      file.id = that.entries.push(file) - 1
+      that.emit('update')
+      cb()
+    })
+
+    head.on('error', function(err) {
+      console.log(err)
+      cb(err)
+    })
+
+    head.end()
+  }
+
   that.selected = null
 
   that.deselect = function () {
@@ -182,6 +221,7 @@ module.exports = function () {
     if (/magnet:/.test(link)) return onmagnet(link, cb)
     if (/\.torrent$/i.test(link)) return ontorrent(link, cb)
     if (/youtube\.com\/watch/i.test(link)) return onyoutube(link, cb)
+    if (/^\/https?:\/\//i.test(link)) return onhttplink(link, cb)
     onfile(link, cb)
   }
 


### PR DESCRIPTION
This PR adds support for http + ipfs.

## http link resolution

Support http links:

```
atom-shell app.js http://gateway.ipfs.io/ipfs/QmTKZgRNwDNZwHtJSjCp6r5FYefzpULfy37JvMt9DwvXse/video.mp4
```

Proxies traffic, with range requests.


## [ipfs](http://ipfs.io) link resolution

This PR also introduces ipfs path resolution. it tries three steps:

1. it first checks a local http gateway at localhost:8080
   (todo make this configurable), deferring to onhttplink
2. if that fails, it attempt to use the mounted filesystem.
3. if that fails, it uses the global gateway at gateway.ipfs.io.

You can try it with:

```
npm install -g go-ipfs
ipfs daemon &
sleep 10 # wait for bootstrap (this will be better)
atom-shell app.js /ipfs/QmTKZgRNwDNZwHtJSjCp6r5FYefzpULfy37JvMt9DwvXse/video.mp4
```
