### PR TITLE
remove prefix from links before matching

### DIFF
--- a/playlist.js
+++ b/playlist.js
@@ -232,11 +232,15 @@ module.exports = function () {
   }
 
   that.add = function (link, cb) {
+    var protoPrefix = "playback://"
+    if (link.substr(0, protoPrefix.length) == protoPrefix)
+      link = link.substr(protoPrefix.length)
+
     if (!cb) cb = noop
     if (/magnet:/.test(link)) return onmagnet(link, cb)
     if (/\.torrent$/i.test(link)) return ontorrent(link, cb)
     if (/youtube\.com\/watch/i.test(link)) return onyoutube(link, cb)
-    if (/^\/(ipfs|ipns)\//i.test(link)) return onipfslink(link, cb)
+    if (/^\/*(ipfs|ipns)\//i.test(link)) return onipfslink(link, cb)
     if (/^\/https?:\/\//i.test(link)) return onhttplink(link, cb)
     onfile(link, cb)
   }


### PR DESCRIPTION
when the playback:// protocol prefix is there, we cannot match other
protocols correctly (e.g. only match `/ipfs/...` with `/^\/ipfs\//`)

I added a "\/*" to the ipfs regex because users will not like
having to enter: playback:///ipfs/...  and playback://ipfs/...
should work

this makes these links work: 
- [playback://ipfs/QmQv4YQNmRPuTTHs4AgBhKEFDdN7eQYeTbSmr8JVWVfury/sintel.mp4](playback://ipfs/QmQv4YQNmRPuTTHs4AgBhKEFDdN7eQYeTbSmr8JVWVfury/sintel.mp4)
- [playback:///ipfs/QmQv4YQNmRPuTTHs4AgBhKEFDdN7eQYeTbSmr8JVWVfury/sintel.mp4](playback://ipfs/QmQv4YQNmRPuTTHs4AgBhKEFDdN7eQYeTbSmr8JVWVfury/sintel.mp4)
