### PR TITLE
Prevent horizontal scrolling on small screens

### DIFF
--- a/css/dark-style.css
+++ b/css/dark-style.css
@@ -8,6 +8,9 @@ body{
   margin: 0;
   padding: 0;
 }
+img {
+  max-width: 100%;
+}
 header h1{
   margin: 0;
   font-size: 40px;
@@ -66,7 +69,7 @@ header .name {
   line-height: 110px;
   margin-left: 10px;
 }
-header span { 
+header span {
   display: inline-block;
 }
 


### PR DESCRIPTION
I clicked a tweet to load the docs site this morning and noticed that the player image wasn't scaling. This makes all of the images responsive.

![screen shot 2015-04-13 at 6 00 21 am](https://cloud.githubusercontent.com/assets/212533/7113494/669afbfc-e1a2-11e4-9705-e13cf0dc20e8.png)
