### PR TITLE
Paste links menu entries

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ var network = require('network-address')
 var chromecasts = require('chromecasts')()
 var $ = require('dombo')
 var titlebar = require('titlebar')()
+var clipboard = require('clipboard')
 var player = require('./player')
 var playlist = require('./playlist')
 var mouseidle = require('./mouseidle')
@@ -98,6 +99,15 @@ $(window).on('contextmenu', function (e) {
     click: function () {
       onTop = !onTop
       remote.getCurrentWindow().setAlwaysOnTop(onTop)
+    }
+  }))
+
+  menu.append(new MenuItem({
+    label: 'Paste Url',
+    accelerator: 'CommandOrControl+V',
+    selector: 'paste:',
+    click: function () {
+      ipc.emit('add-to-playlist', clipboard.readText().split('\n'))
     }
   }))
 

--- a/index.js
+++ b/index.js
@@ -103,9 +103,7 @@ $(window).on('contextmenu', function (e) {
   }))
 
   menu.append(new MenuItem({
-    label: 'Paste Url',
-    accelerator: 'CommandOrControl+V',
-    selector: 'paste:',
+    label: 'Paste link',
     click: function () {
       ipc.emit('add-to-playlist', clipboard.readText().split('\n'))
     }
@@ -402,6 +400,11 @@ var appmenu_template = [
         accelerator: 'Command+O',
         click: function() { ipc.send('open-file-dialog') }
       },
+      {
+        label: 'Add link from clipboard',
+        accelerator: 'CommandOrControl+V',
+        click: function () { ipc.emit('add-to-playlist', clipboard.readText().split('\n')) }
+      }
     ]
   },
   {


### PR DESCRIPTION
This seems to have already been solved on #17, but I'm still unable to paste links on the packaged app.
So, I added entries to both the context menu and the new app menu, which work fine for me:
![screen shot 2015-07-02 at 00 55 00](https://cloud.githubusercontent.com/assets/1211330/8467356/2ab23bc2-2055-11e5-87ee-b259c549b8cd.png)
![screen shot 2015-07-02 at 00 56 02](https://cloud.githubusercontent.com/assets/1211330/8467357/2ae28372-2055-11e5-8430-e07ec37aeeda.png)

