### PR TITLE
Use WebTorrent

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "request": "^2.54.0",
     "srt-to-vtt": "^1.0.2",
     "titlebar": "^1.1.0",
-    "torrent-stream": "^0.18.1",
+    "webtorrent": "^0.58.0",
     "ytdl-core": "^0.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR replaces torrent-stream with WebTorrent. Both have nearly the same API, but WebTorrent can connect to WebRTC peers ("web peers") using Electron's built-in support for WebRTC.

With our recent work on [abstract-chunk-store](https://github.com/mafintosh/abstract-chunk-store), the two codebases are converging more and more, so hopefully no one will notice this change :)