### PR TITLE
small issue - Window move after clicking context menu

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,6 +89,7 @@ var onTop = false
 
 $(window).on('contextmenu', function (e) {
   e.preventDefault()
+  videoDown = false
 
   var menu = new Menu()
 


### PR DESCRIPTION
Hi,

This is my first PR ever, so i'm sorry if i do it wrong 

When i was clicking the context menu (paste a link), the entire app was following the mouse, that was really annoying , so i fixed it

