### PR TITLE
ipcRenderer passes an event object as first argument since electron 0.35.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ var onsubs = function (data) {
   media.subtitles(data)
 }
 
-ipc.on('add-to-playlist', function (links) {
+ipc.on('add-to-playlist', function (event, links) {
   links.forEach(function (link) {
     if (/\.(vtt|srt)$/i.test(link)) {
       fs.createReadStream(link).pipe(vtt()).pipe(concat(onsubs))


### PR DESCRIPTION
Awesome project you've created here.

I wanted to do some development on it so I pulled it down and started poking at stuff; however, I quickly ran into a problem when attempting to add a file to the playlist.  I dug into the devTools and found out that `links` was actually an event object, so I took a look at the electron changelog.  It seems that they changed the API signature to `ipcRenderer.on()`'s callback in 0.35.0 (see https://github.com/electron/electron/releases/tag/v0.35.0) and playback uses ^0.35.4.  I made the change and the "Add Media" is working again.

I'm not sure why the bundled version doesn't exhibit this behavior.