### PR TITLE
add files to recent files when opened with dialog

### DIFF
--- a/app.js
+++ b/app.js
@@ -46,7 +46,10 @@ app.on('ready', function () {
 
   ipc.on('open-file-dialog', function () {
     var files = dialog.showOpenDialog({ properties: [ 'openFile', 'multiSelections' ]})
-    if (files) win.send('add-to-playlist', files)
+    if (files) {
+      files.forEach(app.addRecentDocument)
+      win.send('add-to-playlist', files)
+    }
   })
 
   ipc.on('open-url-in-external', function (event, url) {


### PR DESCRIPTION
During development, I've had to frequently use the Open dialog to add a file to the playlist.  I just found out that electron actually exposes an API for the "recent files" list when right-clicking on the dock icon.  This couple line change allows this to work on OSX but it looks like Windows won't actually show the items in the list without registry changes, so I didn't try that.

Screenshot on OSX:
![screen shot 2016-04-13 at 3 56 42 pm](https://cloud.githubusercontent.com/assets/992373/14512111/0d2c3882-0191-11e6-86a5-279c4b091425.png)
