### PR TITLE
$video.time() is not a function, use that.time() instead

### DIFF
--- a/player.js
+++ b/player.js
@@ -122,7 +122,7 @@ module.exports = function ($video) {
         chromecast.resume()
       }
     } else {
-      if (atEnd && url === lastUrl) $video.time(0)
+      if (atEnd && url === lastUrl) that.time(0)
       if (!url) {
         $video.play()
       } else {


### PR DESCRIPTION
Just found a bug that I really should have caught this while developing the repeat functionality but only tested it against chromecast.  There is no `time()` method on the video element and it was probably meant to be the `that.time()` that is declared above it.