### PR TITLE
add volume icon and hide volume slider unless hovered

### DIFF
--- a/index.css
+++ b/index.css
@@ -270,7 +270,7 @@ body:hover #overlay, body:hover .titlebar {
 }
 
 #controls-repeat {
-  margin: 6px 9px 6px 5px;
+  margin: 6px 0 6px 5px;
   min-width: 40px;
 }
 
@@ -357,24 +357,38 @@ body:hover #overlay, body:hover .titlebar {
 }
 
 #controls-volume {
-  margin: 11px 9px 11px 0;
-  padding: 0;
+  padding: 6px 10px 6px 5px;
   float: left;
+}
+
+#controls-volume .mega-ion {
+  display: inline-block;
+  vertical-align: middle;
+}
+
+#controls-volume:hover #controls-volume-slider {
+  width: 50px;
+}
+
+#controls-volume:hover #controls-volume-slider::-webkit-slider-thumb {
+  width: 7px;
 }
 
 #controls-volume-slider {
   -webkit-appearance: none;
   background: -webkit-gradient(linear, left top, right top, color-stop(50%, #31A357), color-stop(50%, #727374));
-  width: 50px;
+  width: 0;
   height: 3px;
   border-radius: 0px;
+  vertical-align: middle;
+  transition: width 100ms;
 }
 
 #controls-volume-slider::-webkit-slider-thumb {
   -webkit-appearance: none;
   background-color: #31A357;
   opacity: 1.0;
-  width: 7px;
+  width: 0;
   height: 7px;
   border-radius: 3.5px;
 }

--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
             <span class="js-icon mega-ion ion-ios-infinite"></span>
           </div>
           <div id="controls-volume">
+            <span class="mega-ion ion-volume-medium"></span>
             <input type="range" id="controls-volume-slider">
           </div>
           <div id="controls-time" class="center">


### PR DESCRIPTION
This was a prerequisite for me to work on #104 

The control bar will quickly run out of space with extra controls like the repeat and playback speed, so I hid the volume slider behind hover and added a nice animation when it appears.  Gif attached.

![playback-hover-volume-control](https://cloud.githubusercontent.com/assets/992373/14693353/e3c454ca-0712-11e6-922a-9ce475678440.gif)

I also adjusted some spacing between the new volume icon and the repeat icon.
