### PR TITLE
add playback rate functionality - closes #104

### DIFF
--- a/index.css
+++ b/index.css
@@ -270,7 +270,7 @@ body:hover #overlay, body:hover .titlebar {
 }
 
 #controls-repeat {
-  margin: 6px 9px 6px 5px;
+  margin: 6px 0 6px 5px;
   min-width: 40px;
 }
 
@@ -357,24 +357,38 @@ body:hover #overlay, body:hover .titlebar {
 }
 
 #controls-volume {
-  margin: 11px 9px 11px 0;
-  padding: 0;
+  padding: 6px 10px 6px 5px;
   float: left;
+}
+
+#controls-volume .mega-ion {
+  display: inline-block;
+  vertical-align: middle;
+}
+
+#controls-volume:hover #controls-volume-slider {
+  width: 50px;
+}
+
+#controls-volume:hover #controls-volume-slider::-webkit-slider-thumb {
+  width: 7px;
 }
 
 #controls-volume-slider {
   -webkit-appearance: none;
   background: -webkit-gradient(linear, left top, right top, color-stop(50%, #31A357), color-stop(50%, #727374));
-  width: 50px;
+  width: 0;
   height: 3px;
   border-radius: 0px;
+  vertical-align: middle;
+  transition: width 100ms;
 }
 
 #controls-volume-slider::-webkit-slider-thumb {
   -webkit-appearance: none;
   background-color: #31A357;
   opacity: 1.0;
-  width: 7px;
+  width: 0;
   height: 7px;
   border-radius: 3.5px;
 }

--- a/index.css
+++ b/index.css
@@ -340,6 +340,7 @@ body:hover #overlay, body:hover .titlebar {
 
 #controls-time {
   width: 100px;
+  margin-left: 5px;
   float: left;
 }
 
@@ -356,45 +357,51 @@ body:hover #overlay, body:hover .titlebar {
   min-width: 33px;
 }
 
-#controls-volume {
-  padding: 6px 10px 6px 5px;
+#controls-volume,
+#controls-pbrate {
+  padding: 6px 5px;
   float: left;
 }
 
-#controls-volume .mega-ion {
+#controls-volume .mega-ion,
+#controls-pbrate .mega-ion {
   display: inline-block;
   vertical-align: middle;
 }
 
-#controls-volume:hover #controls-volume-slider {
-  width: 50px;
-}
-
-#controls-volume:hover #controls-volume-slider::-webkit-slider-thumb {
-  width: 7px;
-}
-
-#controls-volume-slider {
+.slider {
   -webkit-appearance: none;
-  background: -webkit-gradient(linear, left top, right top, color-stop(50%, #31A357), color-stop(50%, #727374));
-  width: 0;
+  width: 50px;
   height: 3px;
   border-radius: 0px;
   vertical-align: middle;
-  transition: width 100ms;
 }
 
-#controls-volume-slider::-webkit-slider-thumb {
+.slider::-webkit-slider-thumb {
   -webkit-appearance: none;
   background-color: #31A357;
   opacity: 1.0;
-  width: 0;
+  width: 7px;
   height: 7px;
   border-radius: 3.5px;
 }
 
-#controls-volume-slider:focus {
+.slider:focus {
   outline: none;
+}
+
+.hidden-slider .slider,
+.hidden-slider .slider::-webkit-slider-thumb {
+  width: 0;
+  transition: width 100ms;
+}
+
+.hidden-slider:hover .slider {
+  width: 50px;
+}
+
+.hidden-slider:hover .slider::-webkit-slider-thumb {
+  width: 7px;
 }
 
 #controls-name {

--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
             <span class="js-icon mega-ion ion-ios-infinite"></span>
           </div>
           <div id="controls-volume">
+            <span class="mega-ion ion-volume-medium"></span>
             <input type="range" id="controls-volume-slider">
           </div>
           <div id="controls-time" class="center">

--- a/index.html
+++ b/index.html
@@ -36,9 +36,13 @@
           <div id="controls-repeat">
             <span class="js-icon mega-ion ion-ios-infinite"></span>
           </div>
-          <div id="controls-volume">
+          <div id="controls-volume" class="hidden-slider">
             <span class="mega-ion ion-volume-medium"></span>
-            <input type="range" id="controls-volume-slider">
+            <input type="range" id="controls-volume-slider" class="slider">
+          </div>
+          <div id="controls-pbrate" class="hidden-slider">
+            <span class="mega-ion ion-speedometer"></span>
+            <input type="range" id="controls-pbrate-slider" class="slider">
           </div>
           <div id="controls-time" class="center">
             <span id="controls-time-current">‒‒:‒‒</span>

--- a/index.js
+++ b/index.js
@@ -220,6 +220,7 @@ $('#controls-timeline').on('mouseout', function (e) {
 })
 
 var isVolumeSliderClicked = false
+var isPbrateSliderClicked = false
 
 function updateAudioVolume(value) {
   media.volume(value)
@@ -227,6 +228,18 @@ function updateAudioVolume(value) {
 
 function updateVolumeSlider(volume) {
   var val = volume.value * 100
+  volume.style.background = '-webkit-gradient(linear, left top, right top, color-stop(' + val.toString() + '%, #31A357), color-stop(' + val.toString() + '%, #727374))'
+}
+
+function updatePlaybackRate(value) {
+  media.playbackRate(value)
+}
+
+function updatePlaybackRateSlider(volume) {
+  var min = 0.5
+  var max = 4
+  var scaled = (volume.value - min) / (max - min)
+  var val = scaled * 100
   volume.style.background = '-webkit-gradient(linear, left top, right top, color-stop(' + val.toString() + '%, #31A357), color-stop(' + val.toString() + '%, #727374))'
 }
 
@@ -247,6 +260,25 @@ $('#controls-volume-slider').on('mouseup', function (e) {
   updateAudioVolume(volume.value)
   updateVolumeSlider(volume)
   isVolumeSliderClicked = false
+})
+
+$('#controls-pbrate-slider').on('mousemove', function (e) {
+  if (isPbrateSliderClicked) {
+    var volume = $('#controls-pbrate-slider')[0]
+    updatePlaybackRate(volume.value)
+    updatePlaybackRateSlider(volume)
+  }
+})
+
+$('#controls-pbrate-slider').on('mousedown', function (e) {
+  isPbrateSliderClicked = true
+})
+
+$('#controls-pbrate-slider').on('mouseup', function (e) {
+  var volume = $('#controls-pbrate-slider')[0]
+  updatePlaybackRate(volume.value)
+  updatePlaybackRateSlider(volume)
+  isPbrateSliderClicked = false
 })
 
 $(document).on('keydown', function (e) {
@@ -668,8 +700,18 @@ server.listen(0, function () {
   }, 10)
 })
 
-media.volume(0.5)
-$('#controls-volume-slider')[0].setAttribute("value", 0.5)
-$('#controls-volume-slider')[0].setAttribute("min", 0)
-$('#controls-volume-slider')[0].setAttribute("max", 1)
-$('#controls-volume-slider')[0].setAttribute("step", 0.05)
+var volumeSlider = $('#controls-volume-slider')[0]
+volumeSlider.setAttribute("value", 0.5)
+volumeSlider.setAttribute("min", 0)
+volumeSlider.setAttribute("max", 1)
+volumeSlider.setAttribute("step", 0.05)
+updateAudioVolume(0.5)
+updateVolumeSlider(volumeSlider)
+
+var pbrateSlider = $('#controls-pbrate-slider')[0]
+pbrateSlider.setAttribute("value", 1)
+pbrateSlider.setAttribute("min", 0.5)
+pbrateSlider.setAttribute("max", 4)
+pbrateSlider.setAttribute("step", 0.25)
+updatePlaybackRate(1)
+updatePlaybackRateSlider(pbrateSlider)

--- a/player.js
+++ b/player.js
@@ -176,5 +176,9 @@ module.exports = function ($video) {
     $video.volume = value
   }
 
+  that.playbackRate = function (value) {
+    $video.playbackRate = value
+  }
+
   return that
 }


### PR DESCRIPTION
This relies on #105 and will result in a cleaner diff once that is merged.

Added functionality and UI for adjusting the playback speed.  I set the minimum speed at 0.5x because any lower and chrome seemed to mute the audio and I used 4x as the max speed because that is what VLC uses.

I used a speedometer icon because that is what iMovie uses for it's playback rate icon.

I also made the hidden/hover slider stuff generic/reusable.

Gif!
![playback-speed](https://cloud.githubusercontent.com/assets/992373/14694817/266f55c8-0721-11e6-806b-81c6738fdbfe.gif)
