### PR TITLE
Update WebTorrent & its trackers

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "roboto-fontface": "^0.4.2",
     "srt-to-vtt": "^1.0.2",
     "titlebar": "^1.1.0",
-    "webtorrent": "^0.63.3",
+    "webtorrent": "^0.x",
     "ytdl-core": "^0.5.1"
   },
   "devDependencies": {

--- a/playlist.js
+++ b/playlist.js
@@ -22,8 +22,14 @@ module.exports = function () {
     var subtitles = {}
 
     engine.add(link, {
-      announce: [ 'wss://tracker.webtorrent.io' ]
-    }, function (torrent) {
+        tracker: {
+          announce: [ 
+            'wss://tracker.btorrent.xyz',
+            'wss://tracker.openwebtorrent.com',
+            'wss://tracker.fastcast.nz'
+          ]
+        }
+      }, function (torrent) {
       console.log('torrent ready')
 
       torrent.files.forEach(function (f) {


### PR DESCRIPTION
From my tracker I noticed that there are many clients using 0.91 version and noticed many were playback.

This PR updates the dependency to use 0.x (Caret before version 1.0.0 is useless) and uses the latest API. It also updates the trackers to the 3 community trackers running at this moment.
